### PR TITLE
Remove references to nonexistent id columns in join table

### DIFF
--- a/routes/offers.js
+++ b/routes/offers.js
@@ -6,7 +6,7 @@ const knex = require('../knex')
 router.get('/:userid', (req, res, next) => {
 	knex
 	// SELECT offers.id, categories.title
-	.select('offers.id', 'categories.title')
+		.select('categories.title')
 	// FROM offers
 	.from('offers')
 	// INNER JOIN categories

--- a/routes/requests.js
+++ b/routes/requests.js
@@ -6,7 +6,7 @@ const knex = require('../knex')
 router.get('/:userid', (req, res, next) => {
 	knex
 	// SELECT requests.id, categories.title
-	.select('requests.id', 'categories.title')
+		.select('categories.title')
 	// FROM requests
 	.from('requests')
 	// INNER JOIN categories


### PR DESCRIPTION
Join tables use the tuple of the foreign ids they join as their primary key.  This was referencing the offer and request id which don't exist since they're no longer part of the join table.  Removing them from the query is safe because they're not useful anyway.

Tested the offer and request routes to ensure they work now and they do.